### PR TITLE
Remove dotenv dependency and fix stdout/stderr handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp[cli]",
     "httpx",
-    "python-dotenv",
 ]
 
 [project.optional-dependencies]

--- a/src/polymarket_mcp_server/main.py
+++ b/src/polymarket_mcp_server/main.py
@@ -3,11 +3,10 @@ import sys
 from polymarket_mcp_server.server import mcp, config
 
 def setup_environment():
-    print("Using environment variables for configuration")
-
-    print(f"Polymarket API configuration:")
-    print(f"  API URL: {config.api_url}")
-    print(f"  Chain ID: {config.chain_id}")
+    sys.stderr.write("Using environment variables for configuration\n")
+    sys.stderr.write(f"Polymarket API configuration:\n")
+    sys.stderr.write(f"  API URL: {config.api_url}\n")
+    sys.stderr.write(f"  Chain ID: {config.chain_id}\n")
     
     return True
 
@@ -16,8 +15,8 @@ def run_server():
     if not setup_environment():
         sys.exit(1)
     
-    print("\nStarting Polymarket MCP Server...")
-    print("Running server in standard mode...")
+    sys.stderr.write("\nStarting Polymarket MCP Server...\n")
+    sys.stderr.write("Running server in standard mode...\n")
     
     # Run the server with the stdio transport
     mcp.run(transport="stdio")

--- a/src/polymarket_mcp_server/server.py
+++ b/src/polymarket_mcp_server/server.py
@@ -7,10 +7,8 @@ from typing import Any, Dict, List, Optional, Union
 from dataclasses import dataclass
 import httpx
 
-import dotenv
 from mcp.server.fastmcp import FastMCP
 
-dotenv.load_dotenv()
 mcp = FastMCP("Polymarket MCP")
 
 @dataclass
@@ -157,5 +155,5 @@ async def search_markets_resource(query: str) -> str:
         return f"Error searching markets: {str(e)}"
 
 if __name__ == "__main__":
-    print(f"Starting Polymarket MCP Server...")
+    sys.stderr.write(f"Starting Polymarket MCP Server...\n")
     mcp.run()


### PR DESCRIPTION
## Changes

This PR implements the following improvements to fix JSON parsing errors when running with Claude desktop:

1. Removes the python-dotenv dependency entirely
2. Redirects all logging to stderr instead of stdout
3. Uses environment variables directly with defaults

## Why

The previous implementation encountered JSON parsing errors when running with Claude desktop because:
- Debug logs were being printed to stdout where Claude expects only valid JSON
- The dotenv module was generating error messages when no .env file was found

These changes align the code with the working chess-mcp implementation approach, which doesn't use dotenv and correctly handles stdout/stderr separation.

## Implementation Details

1. **server.py**:
   - Removed the dotenv import and load_dotenv() call
   - Changed the __main__ debug output to use sys.stderr.write()
   - Kept the environment variable config with defaults

2. **main.py**:
   - Changed all print statements to sys.stderr.write()
   - Kept the same functionality but ensured all logs go to stderr

3. **pyproject.toml**:
   - Removed the "python-dotenv" dependency

This approach ensures all debug/info messages go to stderr while keeping stdout clean for JSON communication with Claude.
