### PR TITLE
Add 'latest' tag to Docker image when pushing from main branch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,6 +40,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Changes

This PR adds a 'latest' tag to the Docker image when building and pushing from the main branch.

## Implementation

- Updated the `docker-build.yml` workflow file to include a 'latest' tag configuration in the Docker metadata action
- Added a condition to only apply the 'latest' tag when building from the default branch (main)
- Used the following tag configuration:
  ```yaml
  type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
  ```

## Benefits

- Makes it easier to pull the most recent version of the image without specifying a specific tag
- Follows Docker best practices for container image tagging
- Simplifies deployment and usage in development environments

## Testing

This change has been tested to ensure:
- The 'latest' tag is correctly applied when pushing to main
- The condition only enables the tag on the default branch
- Existing tags are preserved

The tagging mechanism uses the official Docker metadata action recommended approach for 'latest' tagging.