### PR TITLE
Fix list response validation error by wrapping API lists in dicts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MCP (Model Context Protocol) server that wraps Polymarket's Gamma Markets API, exposing prediction market data as MCP tools and resources for AI assistants like Claude Desktop.
+
+## Commands
+
+```bash
+# Setup
+uv venv && source .venv/bin/activate
+uv pip install -e ".[dev]"
+
+# Run tests
+pytest
+
+# Run a single test
+pytest tests/unit/test_server.py::test_function_name
+
+# Run with coverage (default via pyproject.toml addopts)
+pytest --cov=src --cov-report=term-missing
+
+# Lint
+flake8 src tests
+
+# Run server directly
+uv run -m polymarket_mcp_server.main
+
+# Build Docker image
+docker build -t polymarket-mcp-server .
+```
+
+## Architecture
+
+- **`src/polymarket_mcp_server/server.py`** — Core file. Defines the `FastMCP` server instance (`mcp`), all MCP tools (`@mcp.tool`) and resources (`@mcp.resource`), the `GammaConfig` dataclass, and the `make_api_request` helper. All API calls go through `make_api_request` which uses `httpx.AsyncClient` against the Gamma API.
+- **`src/polymarket_mcp_server/main.py`** — Entry point. Imports `mcp` and `config` from `server.py`, sets up environment via `dotenv`, and runs `mcp.run(transport="stdio")`.
+- **Tools** are async functions decorated with `@mcp.tool` in `server.py`. They correspond to Gamma API endpoints (`/markets`, `/events`, etc.).
+- **Resources** are `@mcp.resource` decorated functions that return JSON strings, wrapping the tool functions.
+
+## Key Details
+
+- Python >=3.10, uses `uv` for dependency management
+- Config via environment variables: `GAMMA_API_URL` (default: `https://gamma-api.polymarket.com`), `GAMMA_REQUIRES_AUTH` (default: `false`)
+- `.env` file support via `python-dotenv` (copy `.env.template` to `.env`)
+- Server communicates over stdio transport (MCP protocol)
+- Tests use `pytest-asyncio` and `pytest-mock`; test files are in `tests/` and `tests/unit/`

--- a/src/polymarket_mcp_server/server.py
+++ b/src/polymarket_mcp_server/server.py
@@ -28,16 +28,16 @@ config = GammaConfig(
     requires_auth=os.environ.get("GAMMA_REQUIRES_AUTH", "false").lower() == "true"
 )
 
-async def make_api_request(endpoint: str, params: Dict[str, Any] = None, method: str = "GET", data: Dict[str, Any] = None) -> Dict[str, Any]:
+async def make_api_request(endpoint: str, params: Dict[str, Any] = None, method: str = "GET", data: Dict[str, Any] = None) -> Any:
     """Make a request to the Polymarket Gamma API."""
     url = f"{config.api_url.rstrip('/')}/{endpoint.lstrip('/')}"
     headers = {"Content-Type": "application/json"}
-    
+
     # Add authentication if needed in the future
     if config.requires_auth:
         # Implementation would depend on Gamma API auth requirements
         pass
-    
+
     async with httpx.AsyncClient() as client:
         if method == "GET":
             response = await client.get(url, headers=headers, params=params or {})
@@ -45,7 +45,7 @@ async def make_api_request(endpoint: str, params: Dict[str, Any] = None, method:
             response = await client.post(url, headers=headers, json=data, params=params or {})
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
-        
+
         response.raise_for_status()
         return response.json()
 
@@ -178,6 +178,8 @@ async def get_markets(
             params["related_tags"] = related_tags
         
         response = await make_api_request("markets", params=params)
+        if isinstance(response, list):
+            return {"markets": response}
         return response
     except Exception as e:
         sys.stderr.write(f"Error getting markets: {str(e)}\n")
@@ -214,7 +216,10 @@ async def get_order_book(market_id: str, outcome_id: Optional[str] = None) -> Di
         if outcome_id:
             params["outcome_id"] = outcome_id
             
-        return await make_api_request(f"markets/{market_id}/orderbook", params=params)
+        response = await make_api_request(f"markets/{market_id}/orderbook", params=params)
+        if isinstance(response, list):
+            return {"orderbook": response}
+        return response
     except Exception as e:
         sys.stderr.write(f"Error getting order book: {str(e)}\n")
         return {"error": str(e)}
@@ -233,7 +238,10 @@ async def get_recent_trades(market_id: str, limit: int = 50) -> Dict[str, Any]:
     """
     try:
         params = {"limit": limit}
-        return await make_api_request(f"markets/{market_id}/trades", params=params)
+        response = await make_api_request(f"markets/{market_id}/trades", params=params)
+        if isinstance(response, list):
+            return {"trades": response}
+        return response
     except Exception as e:
         sys.stderr.write(f"Error getting recent trades: {str(e)}\n")
         return {"trades": []}
@@ -252,7 +260,10 @@ async def get_market_history(market_id: str, resolution: str = "hour") -> Dict[s
     """
     try:
         params = {"resolution": resolution}
-        return await make_api_request(f"markets/{market_id}/history", params=params)
+        response = await make_api_request(f"markets/{market_id}/history", params=params)
+        if isinstance(response, list):
+            return {"history": response}
+        return response
     except Exception as e:
         sys.stderr.write(f"Error getting market history: {str(e)}\n")
         return {"history": []}
@@ -272,7 +283,10 @@ async def search_markets(query: str, limit: int = 20) -> Dict[str, Any]:
     try:
         # Using the slug parameter for search
         params = {"slug": query, "limit": limit}
-        return await make_api_request("markets", params=params)
+        response = await make_api_request("markets", params=params)
+        if isinstance(response, list):
+            return {"markets": response}
+        return response
     except Exception as e:
         sys.stderr.write(f"Error searching markets: {str(e)}\n")
         return {"markets": []}
@@ -426,7 +440,10 @@ async def get_events(
         elif tag_slug:
             params["tag_slug"] = tag_slug
             
-        return await make_api_request("events", params=params)
+        response = await make_api_request("events", params=params)
+        if isinstance(response, list):
+            return {"events": response}
+        return response
     except Exception as e:
         sys.stderr.write(f"Error getting events: {str(e)}\n")
         return {"events": []}

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -15,101 +15,49 @@ from polymarket_mcp_server.server import config
 class TestMain:
     def test_setup_environment_with_env_file(self):
         """Test setup_environment when .env file is found."""
-        with patch('polymarket_mcp_server.main.dotenv.load_dotenv', return_value=True), \
-             patch('polymarket_mcp_server.main.print') as mock_print:
-            
-            # Set some test values
+        with patch('polymarket_mcp_server.main.load_dotenv', return_value=True):
             original_api_url = config.api_url
-            original_chain_id = config.chain_id
-            
+
             try:
-                config.api_url = "https://test.polymarket.com"
-                config.chain_id = 999
-                
+                config.api_url = "https://test-gamma.polymarket.com"
+
                 result = main.setup_environment()
-                
-                # Verify that the function returns True
+
                 assert result is True
-                
-                # Verify the print statements
-                mock_print.assert_any_call("Loaded environment variables from .env file")
-                mock_print.assert_any_call("Polymarket API configuration:")
-                mock_print.assert_any_call(f"  API URL: {config.api_url}")
-                mock_print.assert_any_call(f"  Chain ID: {config.chain_id}")
             finally:
-                # Restore original values
                 config.api_url = original_api_url
-                config.chain_id = original_chain_id
-    
+
     def test_setup_environment_without_env_file(self):
-        """Test setup_environment when .env file is not found."""
-        with patch('polymarket_mcp_server.main.dotenv.load_dotenv', return_value=False), \
-             patch('polymarket_mcp_server.main.print') as mock_print:
-            
-            # Set some test values
+        """Test setup_environment when .env loading raises."""
+        with patch('polymarket_mcp_server.main.load_dotenv', side_effect=Exception("no .env")):
             original_api_url = config.api_url
-            original_chain_id = config.chain_id
-            
+
             try:
-                config.api_url = "https://test.polymarket.com"
-                config.chain_id = 999
-                
+                config.api_url = "https://test-gamma.polymarket.com"
+
                 result = main.setup_environment()
-                
-                # Verify that the function returns True
+
                 assert result is True
-                
-                # Verify the print statements
-                mock_print.assert_any_call("No .env file found or could not load it - using environment variables")
-                mock_print.assert_any_call("Polymarket API configuration:")
-                mock_print.assert_any_call(f"  API URL: {config.api_url}")
-                mock_print.assert_any_call(f"  Chain ID: {config.chain_id}")
             finally:
-                # Restore original values
                 config.api_url = original_api_url
-                config.chain_id = original_chain_id
-    
-    def test_setup_environment_missing_api_url(self):
-        """Test setup_environment when API URL is missing."""
-        with patch('polymarket_mcp_server.main.dotenv.load_dotenv', return_value=True), \
-             patch('polymarket_mcp_server.main.print') as mock_print:
-            
-            # Set some test values
-            original_api_url = config.api_url
-            
-            try:
-                config.api_url = ""
-                
-                result = main.setup_environment()
-                
-                # Verify that the function returns True (since API URL is optional)
-                assert result is True
-                
-                # Verify the warning print statements
-                mock_print.assert_any_call("WARNING: POLYMARKET_API_URL environment variable is not set")
-                mock_print.assert_any_call("Using default API URL: https://clob.polymarket.com")
-            finally:
-                # Restore original values
-                config.api_url = original_api_url
-    
+
     def test_run_server_successful(self):
         """Test run_server when setup is successful."""
         with patch('polymarket_mcp_server.main.setup_environment', return_value=True), \
              patch('polymarket_mcp_server.main.mcp.run') as mock_run, \
-             patch('polymarket_mcp_server.main.print'):
-            
+             patch('sys.stderr'):
+
             main.run_server()
-            
-            # Verify that mcp.run was called with correct arguments
+
             mock_run.assert_called_once_with(transport="stdio")
-    
+
     def test_run_server_failed_setup(self):
         """Test run_server when setup fails."""
         with patch('polymarket_mcp_server.main.setup_environment', return_value=False), \
              patch('polymarket_mcp_server.main.sys.exit') as mock_exit, \
-             patch('polymarket_mcp_server.main.print'):
-            
+             patch('polymarket_mcp_server.main.mcp.run'), \
+             patch('sys.stderr'):
+
             main.run_server()
-            
-            # Verify that sys.exit was called with the correct error code
+
             mock_exit.assert_called_once_with(1)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -32,223 +32,189 @@ def mock_make_api_request():
 @pytest.mark.asyncio
 async def test_get_markets(mock_make_api_request):
     """Test the get_markets function."""
-    # Set up mock response
-    mock_response = {"markets": [{"id": "123", "name": "Test Market"}]}
+    # Set up mock response - Gamma API returns a list
+    mock_response = [{"id": "123", "name": "Test Market"}]
     mock_make_api_request.return_value = mock_response
-    
+
     # Execute the function
     result = await get_markets()
-    
+
     # Verify the call arguments
     mock_make_api_request.assert_called_once_with("markets", params={})
-    
-    # Verify the result
-    assert result == [{"id": "123", "name": "Test Market"}]
+
+    # Verify the result is wrapped in a dict
+    assert result == {"markets": [{"id": "123", "name": "Test Market"}]}
 
 
 @pytest.mark.asyncio
 async def test_get_markets_with_status(mock_make_api_request):
     """Test the get_markets function with status filter."""
-    # Set up mock response
-    mock_response = {"markets": [{"id": "123", "name": "Test Market", "status": "OPEN"}]}
+    mock_response = [{"id": "123", "name": "Test Market", "active": True}]
     mock_make_api_request.return_value = mock_response
-    
-    # Execute the function
-    result = await get_markets(status="OPEN")
-    
-    # Verify the call arguments
-    mock_make_api_request.assert_called_once_with("markets", params={"status": "OPEN"})
-    
-    # Verify the result
-    assert result == [{"id": "123", "name": "Test Market", "status": "OPEN"}]
+
+    # Execute with status="open" which maps to active=True
+    result = await get_markets(status="open")
+
+    # Verify active param is set from status
+    mock_make_api_request.assert_called_once_with("markets", params={"active": True})
+
+    assert result == {"markets": [{"id": "123", "name": "Test Market", "active": True}]}
 
 
 @pytest.mark.asyncio
 async def test_get_market_by_id(mock_make_api_request):
     """Test the get_market_by_id function."""
-    # Set up test parameters
     market_id = "market_123"
-    
-    # Set up mock response
+
     mock_response = {"id": market_id, "name": "Test Market", "description": "Test Description"}
     mock_make_api_request.return_value = mock_response
-    
-    # Execute the function
+
     result = await get_market_by_id(market_id)
-    
-    # Verify the call arguments
+
     mock_make_api_request.assert_called_once_with(f"markets/{market_id}")
-    
-    # Verify the result
     assert result == mock_response
 
 
 @pytest.mark.asyncio
 async def test_search_markets(mock_make_api_request):
     """Test the search_markets function."""
-    # Set up test parameters
     query = "election"
-    
-    # Set up mock response
-    mock_response = {"markets": [{"id": "123", "name": "Election Market"}]}
+
+    mock_response = [{"id": "123", "name": "Election Market"}]
     mock_make_api_request.return_value = mock_response
-    
-    # Execute the function
+
     result = await search_markets(query)
-    
-    # Verify the call arguments
-    mock_make_api_request.assert_called_once_with("markets/search", params={"q": query, "limit": 20})
-    
-    # Verify the result
-    assert result == [{"id": "123", "name": "Election Market"}]
+
+    mock_make_api_request.assert_called_once_with("markets", params={"slug": query, "limit": 20})
+
+    assert result == {"markets": [{"id": "123", "name": "Election Market"}]}
 
 
 @pytest.mark.asyncio
 async def test_get_order_book(mock_make_api_request):
     """Test the get_order_book function."""
-    # Set up test parameters
     market_id = "market_123"
-    
-    # Set up mock response
+
     mock_response = {"bids": [], "asks": []}
     mock_make_api_request.return_value = mock_response
-    
-    # Execute the function
+
     result = await get_order_book(market_id)
-    
-    # Verify the call arguments
-    mock_make_api_request.assert_called_once_with("orderbook", params={"marketId": market_id})
-    
-    # Verify the result
+
+    mock_make_api_request.assert_called_once_with(f"markets/{market_id}/orderbook", params={})
     assert result == mock_response
 
 
 @pytest.mark.asyncio
 async def test_get_order_book_with_outcome(mock_make_api_request):
     """Test the get_order_book function with outcome filter."""
-    # Set up test parameters
     market_id = "market_123"
     outcome_id = "outcome_456"
-    
-    # Set up mock response
+
     mock_response = {"bids": [{"price": "0.5", "size": "100"}], "asks": []}
     mock_make_api_request.return_value = mock_response
-    
-    # Execute the function
+
     result = await get_order_book(market_id, outcome_id)
-    
-    # Verify the call arguments
-    mock_make_api_request.assert_called_once_with("orderbook", params={"marketId": market_id, "outcomeId": outcome_id})
-    
-    # Verify the result
+
+    mock_make_api_request.assert_called_once_with(
+        f"markets/{market_id}/orderbook", params={"outcome_id": outcome_id}
+    )
     assert result == mock_response
 
 
 @pytest.mark.asyncio
 async def test_get_recent_trades(mock_make_api_request):
     """Test the get_recent_trades function."""
-    # Set up test parameters
     market_id = "market_123"
-    
-    # Set up mock response
-    mock_response = {"trades": [{"price": "0.75", "size": "50", "timestamp": "2025-04-17T12:00:00Z"}]}
+
+    mock_response = [{"price": "0.75", "size": "50", "timestamp": "2025-04-17T12:00:00Z"}]
     mock_make_api_request.return_value = mock_response
-    
-    # Execute the function
+
     result = await get_recent_trades(market_id)
-    
-    # Verify the call arguments
-    mock_make_api_request.assert_called_once_with("trades", params={"marketId": market_id, "limit": 50})
-    
-    # Verify the result
-    assert result == [{"price": "0.75", "size": "50", "timestamp": "2025-04-17T12:00:00Z"}]
+
+    mock_make_api_request.assert_called_once_with(
+        f"markets/{market_id}/trades", params={"limit": 50}
+    )
+    assert result == {"trades": [{"price": "0.75", "size": "50", "timestamp": "2025-04-17T12:00:00Z"}]}
 
 
 @pytest.mark.asyncio
 async def test_get_recent_trades_with_limit(mock_make_api_request):
     """Test the get_recent_trades function with custom limit."""
-    # Set up test parameters
     market_id = "market_123"
     limit = 25
-    
-    # Set up mock response
-    mock_response = {"trades": [{"price": "0.75", "size": "50"}]}
+
+    mock_response = [{"price": "0.75", "size": "50"}]
     mock_make_api_request.return_value = mock_response
-    
-    # Execute the function
+
     result = await get_recent_trades(market_id, limit)
-    
-    # Verify the call arguments
-    mock_make_api_request.assert_called_once_with("trades", params={"marketId": market_id, "limit": limit})
-    
-    # Verify the result
-    assert result == [{"price": "0.75", "size": "50"}]
+
+    mock_make_api_request.assert_called_once_with(
+        f"markets/{market_id}/trades", params={"limit": limit}
+    )
+    assert result == {"trades": [{"price": "0.75", "size": "50"}]}
 
 
 @pytest.mark.asyncio
 async def test_get_market_history(mock_make_api_request):
     """Test the get_market_history function."""
-    # Set up test parameters
     market_id = "market_123"
-    
-    # Set up mock response
-    mock_response = {"history": [{"timestamp": "2025-04-17T00:00:00Z", "price": "0.65", "volume": "1000"}]}
+
+    mock_response = [{"timestamp": "2025-04-17T00:00:00Z", "price": "0.65", "volume": "1000"}]
     mock_make_api_request.return_value = mock_response
-    
-    # Execute the function
+
     result = await get_market_history(market_id)
-    
-    # Verify the call arguments
-    mock_make_api_request.assert_called_once_with("markets/history", params={"marketId": market_id, "resolution": "hour"})
-    
-    # Verify the result
-    assert result == [{"timestamp": "2025-04-17T00:00:00Z", "price": "0.65", "volume": "1000"}]
+
+    mock_make_api_request.assert_called_once_with(
+        f"markets/{market_id}/history", params={"resolution": "hour"}
+    )
+    assert result == {"history": [{"timestamp": "2025-04-17T00:00:00Z", "price": "0.65", "volume": "1000"}]}
 
 
 @pytest.mark.asyncio
 async def test_get_market_history_with_resolution(mock_make_api_request):
     """Test the get_market_history function with custom resolution."""
-    # Set up test parameters
     market_id = "market_123"
     resolution = "day"
-    
-    # Set up mock response
-    mock_response = {"history": [{"timestamp": "2025-04-17", "price": "0.65", "volume": "5000"}]}
+
+    mock_response = [{"timestamp": "2025-04-17", "price": "0.65", "volume": "5000"}]
     mock_make_api_request.return_value = mock_response
-    
-    # Execute the function
+
     result = await get_market_history(market_id, resolution)
-    
-    # Verify the call arguments
-    mock_make_api_request.assert_called_once_with("markets/history", params={"marketId": market_id, "resolution": resolution})
-    
-    # Verify the result
-    assert result == [{"timestamp": "2025-04-17", "price": "0.65", "volume": "5000"}]
+
+    mock_make_api_request.assert_called_once_with(
+        f"markets/{market_id}/history", params={"resolution": resolution}
+    )
+    assert result == {"history": [{"timestamp": "2025-04-17", "price": "0.65", "volume": "5000"}]}
+
+
+@pytest.mark.asyncio
+async def test_get_markets_dict_response(mock_make_api_request):
+    """Test that get_markets passes through dict responses unchanged."""
+    mock_response = {"markets": [{"id": "123"}], "next_cursor": "abc"}
+    mock_make_api_request.return_value = mock_response
+
+    result = await get_markets()
+    assert result == mock_response
 
 
 @pytest.mark.asyncio
 async def test_make_api_request_get():
     """Test the make_api_request function with GET method."""
-    # Mock httpx.AsyncClient
     mock_client = AsyncMock()
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": "test"}
     mock_client.get.return_value = mock_response
-    
-    # Patch httpx.AsyncClient
+
     with patch('httpx.AsyncClient') as mock_async_client:
         mock_async_client.return_value.__aenter__.return_value = mock_client
         mock_async_client.return_value.__aexit__.return_value = None
-        
-        # Call function
+
         endpoint = "test"
         params = {"param1": "value1"}
         result = await make_api_request(endpoint, params=params)
-        
-        # Verify result
+
         assert result == {"data": "test"}
-        
-        # Verify method calls
+
         url = f"{config.api_url.rstrip('/')}/{endpoint.lstrip('/')}"
         mock_client.get.assert_called_once()
         args, kwargs = mock_client.get.call_args
@@ -260,22 +226,18 @@ async def test_make_api_request_get():
 @pytest.mark.asyncio
 async def test_make_api_request_error_handling():
     """Test that make_api_request handles errors correctly."""
-    # Mock httpx.AsyncClient
     mock_client = AsyncMock()
     mock_response = MagicMock()
     mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
         "404 Not Found", request=MagicMock(), response=MagicMock()
     )
     mock_client.get.return_value = mock_response
-    
-    # Patch httpx.AsyncClient
+
     with patch('httpx.AsyncClient') as mock_async_client:
         mock_async_client.return_value.__aenter__.return_value = mock_client
         mock_async_client.return_value.__aexit__.return_value = None
-        
-        # Test that HTTPStatusError is raised
+
         with pytest.raises(httpx.HTTPStatusError):
             await make_api_request("test")
-        
-        # Verify method was called
+
         mock_client.get.assert_called_once()


### PR DESCRIPTION
The Gamma API returns JSON arrays for list endpoints (markets, events, trades, history), but MCP tool output schema expects a dict. This caused validation errors like "Input should be a valid dictionary".

Wrap list responses in named dicts (e.g. {"markets": [...]}) in all affected tools. Update stale unit tests to match current implementation.